### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Textures/Shadow Ramps/4ramptest.psd.meta
 Textures/Shadow Ramps/TestRampMap.psd
 Textures/Shadow Ramps/TestRampMap.psd.meta
 Textures/Shadow Ramps/MGPresets/MultiGradient_NyrraDemon.asset
+Textures/Shadow Ramps/MGPresets/MultiGradient_NyrraDemon.asset.meta

--- a/Editor/XSGradientEditor.cs
+++ b/Editor/XSGradientEditor.cs
@@ -40,7 +40,7 @@ public class XSGradientEditor : EditorWindow
     private Vector2 scrollPos;
 
     private bool dHelpText = false;
-    private bool dAdvanced = false;
+    //private bool dAdvanced = false;
 
     [MenuItem("Tools/Xiexe/XSToon/Gradient Editor")]
     static public void Init()

--- a/Editor/XSStyles.cs
+++ b/Editor/XSStyles.cs
@@ -6,7 +6,7 @@ using System.IO;
 [InitializeOnLoad]
 public class XSStyles : MonoBehaviour
 {
-    public static string ver = "2.1.0p3";
+    public static string ver = "2.2.0";
 
     //Help URLs
     public static string mainURL = "https://docs.google.com/document/d/1xJ4PID_nwqVm_UCsO2c2gEdiEoWoCGeM_GDK_L8-aZE/edit#bookmark=id.xh0nk8x7ws1g";

--- a/Editor/XSToonInspector.cs
+++ b/Editor/XSToonInspector.cs
@@ -12,88 +12,91 @@ public class XSToonInspector : ShaderGUI
                                 BindingFlags.Instance |
                                 BindingFlags.Static;
 
-    //Assign all properties as null at first to stop hundreds of warnings spamming the log when script gets compiled.
-    //If they aren't we get warnings, because assigning with reflection seems to make Unity think that the properties never actually get used. 
-    //
-        MaterialProperty _TilingMode = null;
-        MaterialProperty _Culling = null;
-        MaterialProperty _MainTex = null;
-        MaterialProperty _Saturation = null;
-        MaterialProperty _Color = null;
-        MaterialProperty _Cutoff = null;
-        MaterialProperty _BumpMap = null;
-        MaterialProperty _BumpScale = null;
-        MaterialProperty _DetailNormalMap = null;
-        MaterialProperty _DetailMask = null;
-        MaterialProperty _DetailNormalMapScale = null;
-        MaterialProperty _ReflectionMode = null;
-        MaterialProperty _ReflectionBlendMode = null;
-        MaterialProperty _MetallicGlossMap = null;
-        MaterialProperty _BakedCubemap = null;
-        MaterialProperty _Matcap = null;
-        MaterialProperty _MatcapTint = null;
-        MaterialProperty _ReflectivityMask = null;
-        MaterialProperty _Metallic = null;
-        MaterialProperty _Glossiness = null;
-        MaterialProperty _Reflectivity = null;
-        MaterialProperty _ClearCoat = null;
-        MaterialProperty _ClearcoatStrength = null;
-        MaterialProperty _ClearcoatSmoothness = null;
-        MaterialProperty _EmissionMap = null;
-        MaterialProperty _ScaleWithLight = null;
-        MaterialProperty _ScaleWithLightSensitivity = null;
-        MaterialProperty _EmissionColor = null;
-        MaterialProperty _EmissionToDiffuse = null;
-        MaterialProperty _RimColor = null;
-        MaterialProperty _RimIntensity = null;
-        MaterialProperty _RimRange = null;
-        MaterialProperty _RimThreshold = null;
-        MaterialProperty _RimSharpness = null;
-        MaterialProperty _SpecMode = null;
-        MaterialProperty _SpecularStyle = null;
-        MaterialProperty _SpecularMap = null;
-        MaterialProperty _SpecularIntensity = null;
-        MaterialProperty _SpecularArea = null;
-        MaterialProperty _AnisotropicAX = null;
-        MaterialProperty _AnisotropicAY = null;
-        MaterialProperty _SpecularAlbedoTint = null;
-        MaterialProperty _RampSelectionMask = null;
-        MaterialProperty _Ramp = null;
-        MaterialProperty _ShadowRim = null;
-        MaterialProperty _ShadowRimRange = null;
-        MaterialProperty _ShadowRimThreshold = null;
-        MaterialProperty _ShadowRimSharpness = null;
-        MaterialProperty _OcclusionMap = null;
-        MaterialProperty _OcclusionColor = null;
-        MaterialProperty _ThicknessMap = null;
-        MaterialProperty _SSColor = null;
-        MaterialProperty _SSDistortion = null;
-        MaterialProperty _SSPower = null;
-        MaterialProperty _SSScale = null;
-        MaterialProperty _SSSRange = null;
-        MaterialProperty _SSSSharpness = null;
-        //MaterialProperty _HalftoneDotSize = null;
-        //MaterialProperty _HalftoneDotAmount = null;
-        //MaterialProperty _HalftoneLineAmount = null;
-        MaterialProperty _UVSetAlbedo = null;
-        MaterialProperty _UVSetNormal = null;
-        MaterialProperty _UVSetDetNormal = null;
-        MaterialProperty _UVSetDetMask = null;
-        MaterialProperty _UVSetMetallic = null;
-        MaterialProperty _UVSetSpecular = null;
-        MaterialProperty _UVSetReflectivity = null;
-        MaterialProperty _UVSetThickness = null;
-        MaterialProperty _UVSetOcclusion = null;
-        MaterialProperty _UVSetEmission = null;
-        MaterialProperty _Stencil = null;
-        MaterialProperty _StencilComp = null;
-        MaterialProperty _StencilOp = null;
-        MaterialProperty _OutlineMask = null;
-        MaterialProperty _OutlineWidth = null;
-        MaterialProperty _OutlineColor = null;
-        MaterialProperty _ShadowSharpness = null;
-        MaterialProperty _AdvMode = null;
-    //
+//Assign all properties as null at first to stop hundreds of warnings spamming the log when script gets compiled.
+//If they aren't we get warnings, because assigning with reflection seems to make Unity think that the properties never actually get used. 
+//
+    MaterialProperty _VertexColorAlbedo = null;
+    MaterialProperty _TilingMode = null;
+    MaterialProperty _Culling = null;
+    MaterialProperty _MainTex = null;
+    MaterialProperty _Saturation = null;
+    MaterialProperty _Color = null;
+    MaterialProperty _Cutoff = null;
+    MaterialProperty _BumpMap = null;
+    MaterialProperty _BumpScale = null;
+    MaterialProperty _DetailNormalMap = null;
+    MaterialProperty _DetailMask = null;
+    MaterialProperty _DetailNormalMapScale = null;
+    MaterialProperty _ReflectionMode = null;
+    MaterialProperty _ReflectionBlendMode = null;
+    MaterialProperty _MetallicGlossMap = null;
+    MaterialProperty _BakedCubemap = null;
+    MaterialProperty _Matcap = null;
+    MaterialProperty _MatcapTint = null;
+    MaterialProperty _ReflectivityMask = null;
+    MaterialProperty _Metallic = null;
+    MaterialProperty _Glossiness = null;
+    MaterialProperty _Reflectivity = null;
+    MaterialProperty _ClearCoat = null;
+    MaterialProperty _ClearcoatStrength = null;
+    MaterialProperty _ClearcoatSmoothness = null;
+    MaterialProperty _EmissionMap = null;
+    MaterialProperty _ScaleWithLight = null;
+    MaterialProperty _ScaleWithLightSensitivity = null;
+    MaterialProperty _EmissionColor = null;
+    MaterialProperty _EmissionToDiffuse = null;
+    MaterialProperty _RimColor = null;
+    MaterialProperty _RimIntensity = null;
+    MaterialProperty _RimRange = null;
+    MaterialProperty _RimThreshold = null;
+    MaterialProperty _RimSharpness = null;
+    MaterialProperty _SpecMode = null;
+    MaterialProperty _SpecularStyle = null;
+    MaterialProperty _SpecularMap = null;
+    MaterialProperty _SpecularIntensity = null;
+    MaterialProperty _SpecularArea = null;
+    MaterialProperty _AnisotropicAX = null;
+    MaterialProperty _AnisotropicAY = null;
+    MaterialProperty _SpecularAlbedoTint = null;
+    MaterialProperty _RampSelectionMask = null;
+    MaterialProperty _Ramp = null;
+    MaterialProperty _ShadowRim = null;
+    MaterialProperty _ShadowRimRange = null;
+    MaterialProperty _ShadowRimThreshold = null;
+    MaterialProperty _ShadowRimSharpness = null;
+    MaterialProperty _OcclusionMap = null;
+    MaterialProperty _OcclusionColor = null;
+    MaterialProperty _ThicknessMap = null;
+    MaterialProperty _SSColor = null;
+    MaterialProperty _SSDistortion = null;
+    MaterialProperty _SSPower = null;
+    MaterialProperty _SSScale = null;
+    MaterialProperty _SSSRange = null;
+    MaterialProperty _SSSSharpness = null;
+    //MaterialProperty _HalftoneDotSize = null;
+    //MaterialProperty _HalftoneDotAmount = null;
+    //MaterialProperty _HalftoneLineAmount = null;
+    MaterialProperty _UVSetAlbedo = null;
+    MaterialProperty _UVSetNormal = null;
+    MaterialProperty _UVSetDetNormal = null;
+    MaterialProperty _UVSetDetMask = null;
+    MaterialProperty _UVSetMetallic = null;
+    MaterialProperty _UVSetSpecular = null;
+    MaterialProperty _UVSetReflectivity = null;
+    MaterialProperty _UVSetThickness = null;
+    MaterialProperty _UVSetOcclusion = null;
+    MaterialProperty _UVSetEmission = null;
+    MaterialProperty _Stencil = null;
+    MaterialProperty _StencilComp = null;
+    MaterialProperty _StencilOp = null;
+    MaterialProperty _OutlineAlbedoTint = null;
+    MaterialProperty _OutlineLighting = null;
+    MaterialProperty _OutlineMask = null;
+    MaterialProperty _OutlineWidth = null;
+    MaterialProperty _OutlineColor = null;
+    MaterialProperty _ShadowSharpness = null;
+    MaterialProperty _AdvMode = null;
+//
     static bool showMainSettings = true;
     static bool showNormalMapSettings = false;
     static bool showShadows = true;
@@ -141,12 +144,12 @@ public class XSToonInspector : ShaderGUI
             showMainSettings = XSStyles.ShurikenFoldout("Main Settings", showMainSettings);
             if (showMainSettings)
             {
-                materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "The Main Texture."), _MainTex, _Color);
+                materialEditor.TexturePropertySingleLine(new GUIContent("Main Texture", "The main Albedo texture."), _MainTex, _Color);
                 if (isCutout)
                 {
                     materialEditor.ShaderProperty(_Cutoff, new GUIContent("Cutoff", "The Cutoff Amount"), 2);
                 }
-                materialEditor.ShaderProperty(_UVSetAlbedo, new GUIContent("UV Set", "The UV set to use for the Albedo Texture"), 2);
+                materialEditor.ShaderProperty(_UVSetAlbedo, new GUIContent("UV Set", "The UV set to use for the Albedo Texture."), 2);
                 materialEditor.TextureScaleOffsetProperty(_MainTex);
                 materialEditor.ShaderProperty(_Saturation, new GUIContent("Saturation", "Controls saturation of the final output from the shader."));
 
@@ -171,7 +174,7 @@ public class XSToonInspector : ShaderGUI
                     }
                 }
                 
-                materialEditor.TexturePropertySingleLine(new GUIContent("Shadow Ramp", "Shadow Ramp, Dark to Light should be Left to Right, or Down to Up"), _Ramp);
+                materialEditor.TexturePropertySingleLine(new GUIContent("Shadow Ramp", "Shadow Ramp, Dark to Light should be Left to Right"), _Ramp);
                 materialEditor.ShaderProperty(_ShadowSharpness, new GUIContent("Shadow Sharpness", "Controls the sharpness of recieved shadows, as well as the sharpness of 'shadows' from Vertex Lighting."));
 
                 GUILayout.Space(5);
@@ -193,6 +196,8 @@ public class XSToonInspector : ShaderGUI
                 showOutlines = XSStyles.ShurikenFoldout("Outlines", showOutlines);
                 if (showOutlines)
                 {
+                    materialEditor.ShaderProperty(_OutlineLighting, new GUIContent("Outline Lighting", "Makes outlines respect the lighting, or be emissive."));
+                    materialEditor.ShaderProperty(_OutlineAlbedoTint, new GUIContent("Outline Albedo Tint", "Includes the color of the Albedo Texture in the calculation for the color of the outline."));
                     materialEditor.TexturePropertySingleLine(new GUIContent("Outline Mask", "Outline width mask, black will make the outline minimum width."), _OutlineMask);
                     materialEditor.ShaderProperty(_OutlineWidth, new GUIContent("Outline Width", "Width of the Outlines"));
                     XSStyles.constrainedShaderProperty(materialEditor, _OutlineColor, new GUIContent("Outline Color", "Color of the outlines"), 0);
@@ -215,7 +220,7 @@ public class XSToonInspector : ShaderGUI
                 materialEditor.TextureScaleOffsetProperty(_DetailNormalMap);
 
                 GUILayout.Space(5);
-                materialEditor.TexturePropertySingleLine(new GUIContent("Detail Mask", "Mask for Detail Normal Map"), _DetailMask);
+                materialEditor.TexturePropertySingleLine(new GUIContent("Detail Mask", "Mask for Detail Maps"), _DetailMask);
                 materialEditor.ShaderProperty(_UVSetDetMask, new GUIContent("UV Set", "The UV set to use for the Detail Mask"), 2);
                 materialEditor.TextureScaleOffsetProperty(_DetailMask);
 
@@ -329,7 +334,7 @@ public class XSToonInspector : ShaderGUI
                 materialEditor.ShaderProperty(_UVSetThickness, new GUIContent("UV Set", "The UV set to use for the Thickness Map"), 2);
 
                 XSStyles.constrainedShaderProperty(materialEditor, _SSColor, new GUIContent("Subsurface Color", "Subsurface Scattering Color"), 2);
-                materialEditor.ShaderProperty(_SSDistortion, new GUIContent("Subsurface Distortion", "How much the subsurface follows the normals of the mesh, Normal map."), 2);
+                materialEditor.ShaderProperty(_SSDistortion, new GUIContent("Subsurface Distortion", "How much the subsurface should follow the normals of the mesh and/or normal map."), 2);
                 materialEditor.ShaderProperty(_SSPower, new GUIContent("Subsurface Power", "Subsurface Power"), 2);
                 materialEditor.ShaderProperty(_SSScale, new GUIContent("Subsurface Scale", "Subsurface Scale"), 2);
                 materialEditor.ShaderProperty(_SSSRange, new GUIContent("Subsurface Range", "Subsurface Range"), 2);
@@ -341,6 +346,7 @@ public class XSToonInspector : ShaderGUI
                 showAdvanced = XSStyles.ShurikenFoldout("Advanced Settings", showAdvanced);
                 if (showAdvanced)
                 {
+                    materialEditor.ShaderProperty(_VertexColorAlbedo, new GUIContent("Vertex Color Albedo", "Multiplies the vertex color of the mesh by the Albedo texture to derive the final Albedo color."));
                     materialEditor.ShaderProperty(_Stencil, _Stencil.displayName);
                     materialEditor.ShaderProperty(_StencilComp, _StencilComp.displayName);
                     materialEditor.ShaderProperty(_StencilOp, _StencilOp.displayName);

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c23e5908bcdfaf498f03fc626fe8a46
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Main/CGIncludes/XSDefines.cginc
+++ b/Main/CGIncludes/XSDefines.cginc
@@ -8,7 +8,7 @@ struct VertexInput
     float2 uv : TEXCOORD0;
     float2 uv1 : TEXCOORD1;
     float3 normal : NORMAL;
-    float3 tangent : TANGENT;
+    float4 tangent : TANGENT;
     float4 color : COLOR;
 };
 

--- a/Main/CGIncludes/XSDefines.cginc
+++ b/Main/CGIncludes/XSDefines.cginc
@@ -160,7 +160,8 @@ half _OutlineWidth;
 
 int _SpecMode, _SpecularStyle, _ReflectionMode, _ReflectionBlendMode, _ClearCoat;
 
-int _TilingMode, _ScaleWithLight;
+int _TilingMode, _VertexColorAlbedo, _ScaleWithLight;
+int _OutlineAlbedoTint, _OutlineLighting;
 int _UVSetAlbedo, _UVSetNormal, _UVSetDetNormal, 
     _UVSetDetMask, _UVSetMetallic, _UVSetSpecular,
     _UVSetThickness, _UVSetOcclusion, _UVSetReflectivity,

--- a/Main/CGIncludes/XSHelperFunctions.cginc
+++ b/Main/CGIncludes/XSHelperFunctions.cginc
@@ -1,11 +1,8 @@
 void calcNormal(inout XSLighting i)
 {
     
-    half3 nMap = UnpackNormal(i.normalMap);
-    nMap.xy *= _BumpScale;
-
-    half3 detNMap = UnpackNormal(i.detailNormal);
-    // detNMap.xy *= _DetailNormalMapScale * i.detailMask.r;
+    half3 nMap = UnpackScaleNormal(i.normalMap, _BumpScale);
+    half3 detNMap = UnpackScaleNormal(i.detailNormal, _DetailNormalMapScale);
 
     half3 blendedNormal = lerp(nMap, BlendNormals(nMap, detNMap), i.detailMask.r);
 

--- a/Main/CGIncludes/XSLightingFunctions.cginc
+++ b/Main/CGIncludes/XSLightingFunctions.cginc
@@ -258,10 +258,11 @@ half4 calcOutlineColor(XSLighting i, DotProducts d, half3 indirectDiffuse, half4
 {
     half3 outlineColor = half3(0,0,0);
     #if defined(Geometry)
-        outlineColor = _OutlineColor * saturate(i.attenuation * d.ndl) * lightCol.xyz;
-        outlineColor += indirectDiffuse * _OutlineColor;
+        half3 ol = lerp(_OutlineColor, _OutlineColor * i.diffuseColor, _OutlineAlbedoTint);
+        outlineColor = ol * saturate(i.attenuation * d.ndl) * lightCol.rgb;
+        outlineColor += indirectDiffuse * ol;
+        outlineColor = lerp(outlineColor, ol, _OutlineLighting);
     #endif
-
     return half4(outlineColor,1);
 }
 
@@ -286,7 +287,7 @@ half4 calcDiffuse(XSLighting i, DotProducts d, half3 indirectDiffuse, half4 ligh
     half4 diffuse; 
     half4 indirect = indirectDiffuse.xyzz;
     diffuse = ramp * i.attenuation * lightCol + indirect;
-    diffuse = i.albedo * i.color.xyzz * diffuse;
+    diffuse = i.albedo * diffuse;
     return diffuse;
 }
 

--- a/Main/CGIncludes/XSVertFrag.cginc
+++ b/Main/CGIncludes/XSVertFrag.cginc
@@ -116,7 +116,7 @@ float4 frag (
     }
 
     XSLighting o = (XSLighting)0; //Populate Lighting Struct
-    o.albedo = UNITY_SAMPLE_TEX2D(_MainTex, t.albedoUV) * _Color;
+    o.albedo = UNITY_SAMPLE_TEX2D(_MainTex, t.albedoUV) * _Color * lerp(1, float4(i.color.rgb, 1), _VertexColorAlbedo);
     o.specularMap = UNITY_SAMPLE_TEX2D_SAMPLER(_SpecularMap, _MainTex, t.specularMapUV);
     o.metallicGlossMap = UNITY_SAMPLE_TEX2D_SAMPLER(_MetallicGlossMap, _MainTex, t.metallicGlossMapUV);
     o.detailMask = UNITY_SAMPLE_TEX2D_SAMPLER(_DetailMask, _MainTex, t.detailMaskUV);

--- a/Main/CGIncludes/XSVertFrag.cginc
+++ b/Main/CGIncludes/XSVertFrag.cginc
@@ -9,7 +9,8 @@ VertexOutput vert (VertexInput v)
     o.worldPos = mul(unity_ObjectToWorld, v.vertex);
     float3 wnormal = UnityObjectToWorldNormal(v.normal);
     float3 tangent = UnityObjectToWorldDir(v.tangent.xyz);
-    float3 bitangent = cross(tangent, wnormal);
+    half tangentSign = v.tangent.w * unity_WorldTransformParams.w;
+    float3 bitangent = cross(wnormal, tangent) * tangentSign;
     o.ntb[0] = wnormal;
     o.ntb[1] = tangent;
     o.ntb[2] = bitangent;

--- a/Main/Shaders/XSToon2.0 Cutout.shader
+++ b/Main/Shaders/XSToon2.0 Cutout.shader
@@ -1,7 +1,8 @@
 ﻿Shader "Xiexe/Toon2.0/XSToon2.0_Cutout"
 {
-   Properties
+    Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -50,8 +51,8 @@
         _AnisotropicAX("Anisotropic X", Range(0,1)) = 0.25
         _AnisotropicAY("Anisotripic Y", Range(0,1)) = 0.75  
         _SpecularAlbedoTint("Specular Albedo Tint", Range(0,1)) = 1
-        
-        _RampSelectionMask("Ramp Mask", 2D) = "black" {}
+
+        _RampSelectionMask("Ramp Mask", 2D) = "black" {}        
         _Ramp("Shadow Ramp", 2D) = "white" {}
         _ShadowSharpness("Received Shadow Sharpness", Range(0,1)) = 0.5
         _ShadowRim("Shadow Rim Tint", Color) = (1,1,1,1)
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Cutout.shader
+++ b/Main/Shaders/XSToon2.0 Cutout.shader
@@ -111,6 +111,7 @@
             Tags { "LightMode" = "ForwardBase" }
             
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
 
@@ -139,6 +140,7 @@
             Blend One One
 
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             

--- a/Main/Shaders/XSToon2.0 CutoutA2C Outlined.shader
+++ b/Main/Shaders/XSToon2.0 CutoutA2C Outlined.shader
@@ -1,7 +1,8 @@
 ﻿Shader "Xiexe/Toon2.0/XSToon2.0_CutoutA2C_Outlined"
 {
-   Properties
+    Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 CutoutA2C.shader
+++ b/Main/Shaders/XSToon2.0 CutoutA2C.shader
@@ -1,7 +1,8 @@
 ﻿Shader "Xiexe/Toon2.0/XSToon2.0_CutoutA2C"
 {
-     Properties
+    Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 CutoutA2C.shader
+++ b/Main/Shaders/XSToon2.0 CutoutA2C.shader
@@ -111,6 +111,7 @@
             Tags { "LightMode" = "ForwardBase" }
             AlphaToMask On
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             
@@ -139,6 +140,7 @@
             Blend One One
             AlphaToMask On
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             

--- a/Main/Shaders/XSToon2.0 Dithered Outlined.shader
+++ b/Main/Shaders/XSToon2.0 Dithered Outlined.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Dithered.shader
+++ b/Main/Shaders/XSToon2.0 Dithered.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Dithered.shader
+++ b/Main/Shaders/XSToon2.0 Dithered.shader
@@ -111,6 +111,7 @@
             Tags { "LightMode" = "ForwardBase" }
             
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             
@@ -139,6 +140,7 @@
             Blend One One
 
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             

--- a/Main/Shaders/XSToon2.0 Fade.shader
+++ b/Main/Shaders/XSToon2.0 Fade.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Fade.shader
+++ b/Main/Shaders/XSToon2.0 Fade.shader
@@ -113,6 +113,7 @@
             Tags { "LightMode" = "ForwardBase" }
             
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             
@@ -141,6 +142,7 @@
             Blend SrcAlpha One
 
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             

--- a/Main/Shaders/XSToon2.0 Outlined.shader
+++ b/Main/Shaders/XSToon2.0 Outlined.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Transparent.shader
+++ b/Main/Shaders/XSToon2.0 Transparent.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon2.0 Transparent.shader
+++ b/Main/Shaders/XSToon2.0 Transparent.shader
@@ -113,6 +113,7 @@
             Tags { "LightMode" = "ForwardBase" }
             
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             
@@ -141,6 +142,7 @@
             Blend SrcAlpha One
 
             CGPROGRAM
+            #pragma target 3.0
             #pragma vertex vert
             #pragma fragment frag
             

--- a/Main/Shaders/XSToon2.0.shader
+++ b/Main/Shaders/XSToon2.0.shader
@@ -113,6 +113,7 @@
             CGPROGRAM
             //#define Geometry
 
+            #pragma target 3.0
             #pragma vertex vert
             //#pragma geometry geom
             #pragma fragment frag
@@ -142,6 +143,7 @@
             CGPROGRAM
             //#define Geometry
 
+            #pragma target 3.0
             #pragma vertex vert
             //#pragma geometry geom
             #pragma fragment frag

--- a/Main/Shaders/XSToon2.0.shader
+++ b/Main/Shaders/XSToon2.0.shader
@@ -2,6 +2,7 @@
 {
     Properties
     {	
+        [Enum(Off, 0, On, 1)] _VertexColorAlbedo ("Vertex Color Albedo", Int) = 0
         [Enum(Separated, 0, Merged, 1)] _TilingMode ("Tiling Mode", Int) = 0
         [Enum(Off,0,Front,1,Back,2)] _Culling ("Culling Mode", Int) = 2
         _MainTex("Texture", 2D) = "white" {}
@@ -50,8 +51,8 @@
         _AnisotropicAX("Anisotropic X", Range(0,1)) = 0.25
         _AnisotropicAY("Anisotripic Y", Range(0,1)) = 0.75  
         _SpecularAlbedoTint("Specular Albedo Tint", Range(0,1)) = 1
-        
-        _RampSelectionMask("Ramp Mask", 2D) = "black" {}
+
+        _RampSelectionMask("Ramp Mask", 2D) = "black" {}        
         _Ramp("Shadow Ramp", 2D) = "white" {}
         _ShadowSharpness("Received Shadow Sharpness", Range(0,1)) = 0.5
         _ShadowRim("Shadow Rim Tint", Color) = (1,1,1,1)
@@ -62,9 +63,11 @@
         _OcclusionMap("Occlusion", 2D) = "white" {}
         _OcclusionColor("Occlusion Color", Color) = (0,0,0,0)
 
+        [Enum(Off, 0, On, 1)]_OutlineAlbedoTint("Outline Albedo Tint", Int) = 0
+        [Enum(Lit, 0, Emissive, 1)]_OutlineLighting("Outline Lighting", Int) = 0
         _OutlineMask("Outline Mask", 2D) = "white" {}
         _OutlineWidth("Outline Width", Range(0, 5)) = 1
-        _OutlineColor("Outline Color", Color) = (0,0,0,1)
+        [HDR]_OutlineColor("Outline Color", Color) = (0,0,0,1)
 
         _ThicknessMap("Thickness Map", 2D) = "white" {}
         _SSColor ("Subsurface Color", Color) = (0,0,0,0)

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: 5639eb00eb21c504eb382fd7647aca9c
-NativeFormatImporter:
+guid: 86d4b790f390cce47810844e4b4a93d0
+TextScriptImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
prep for 2.2.0 release

- fix normal map issues ( ScruffyRules )
- fix pragma target not being specificed properly in some cases ( ScruffyRules )
- vertex color support off by default, moved to adv settings
- outline lighting mode options for emissive or lit outlines
- add support for tinting outlines by the albedo color