### PR TITLE
Added support for UV-based Audio Link sampling

### DIFF
--- a/Editor/XSToonInspector.cs
+++ b/Editor/XSToonInspector.cs
@@ -153,6 +153,7 @@ namespace XSToon3
         private MaterialProperty _ALGradientOnRed = null;
         private MaterialProperty _ALGradientOnGreen = null;
         private MaterialProperty _ALGradientOnBlue = null;
+        private MaterialProperty _ALUVWidth = null;
 
         //Experimenting
         private MaterialProperty _DissolveBlendPower = null;
@@ -614,6 +615,7 @@ namespace XSToon3
             {
                 bool isAudioLink = material.GetInt("_EmissionAudioLinkChannel") > 0;
                 bool isPackedMapLink = material.GetInt("_EmissionAudioLinkChannel") == 5;
+                bool isUVBased = material.GetInt("_EmissionAudioLinkChannel") == 6;
                 materialEditor.ShaderProperty(_EmissionAudioLinkChannel, new GUIContent("Emission Audio Link", "Use Audio Link for Emission Brightness"));
 
                 if (!isPackedMapLink)
@@ -622,6 +624,9 @@ namespace XSToon3
                     materialEditor.TextureScaleOffsetProperty(_EmissionMap);
                     materialEditor.ShaderProperty(_UVSetEmission, new GUIContent("UV Set", "The UV set to use for the Emission Map"), 2);
                     materialEditor.ShaderProperty(_EmissionToDiffuse, new GUIContent("Tint To Diffuse", "Tints the emission to the Diffuse Color"), 2);
+                    if (isUVBased) {
+                        materialEditor.ShaderProperty(_ALUVWidth, new GUIContent("History Sample Amount", "Controls the amount of Audio Link history to sample."));
+                    }
                 }
                 else
                 {

--- a/Editor/XSToonInspector.cs.meta
+++ b/Editor/XSToonInspector.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 005c83a3d97ccf040bdbfacbf03b42dc
+guid: 4f283915347a6bb4ab61f5aa10e8aeb0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Main/CGIncludes/XSDefines.cginc
+++ b/Main/CGIncludes/XSDefines.cginc
@@ -236,6 +236,7 @@ int _UVSetAlbedo, _UVSetNormal, _UVSetDetNormal,
 int _NormalMapMode, _OutlineUVSelect;
 int _AlphaToMask;
 int _ALGradientOnRed, _ALGradientOnGreen, _ALGradientOnBlue;
+int _ALUVWidth;
 
 //!RDPSDefines
 

--- a/Main/CGIncludes/XSDefines.cginc.meta
+++ b/Main/CGIncludes/XSDefines.cginc.meta
@@ -1,8 +1,9 @@
 fileFormatVersion: 2
-guid: d7083d96cb8a0da48beb300faaf2e125
+guid: acac972a217b8804cbddd19023f998ed
 ShaderImporter:
   externalObjects: {}
   defaultTextures: []
+  nonModifiableTextures: []
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Main/CGIncludes/XSLightingFunctions.cginc
+++ b/Main/CGIncludes/XSLightingFunctions.cginc
@@ -391,7 +391,14 @@ half4 calcEmission(FragmentData i, TextureUV t, DotProducts d, half lightAvg)
             {
                 if(_EmissionAudioLinkChannel != 5)
                 {
-                    int2 aluv = int2(0, (_EmissionAudioLinkChannel-1));
+                    int2 aluv;
+                    if (_EmissionAudioLinkChannel == 6)
+                    {
+                        aluv = int2(t.emissionMapUV.x * _ALUVWidth, t.emissionMapUV.y);
+                    } else
+                    {
+                        aluv = int2(0, (_EmissionAudioLinkChannel-1));
+                    }
                     float alink = lerp(1, AudioLinkData(aluv).x , saturate(_EmissionAudioLinkChannel));
                     emission = lerp(i.emissionMap, i.emissionMap * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor * alink;
                 }

--- a/Main/CGIncludes/XSLightingFunctions.cginc.meta
+++ b/Main/CGIncludes/XSLightingFunctions.cginc.meta
@@ -1,8 +1,9 @@
 fileFormatVersion: 2
-guid: 59e9937e913f34b4c9335c6f6b288c78
+guid: fe07672f5abe37a4eada459dbd1a2f92
 ShaderImporter:
   externalObjects: {}
   defaultTextures: []
+  nonModifiableTextures: []
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Main/Shaders/XSToon3.0.shader
+++ b/Main/Shaders/XSToon3.0.shader
@@ -127,13 +127,14 @@
         [Enum(UV1,0,UV2,1)] _UVSetClipMap("Clip Map UVs", Int) = 0
         [Enum(UV1,0,UV2,1)] _UVSetDissolve("Dissolve Map UVs", Int) = 0
 
-        [Enum(None,0,Bass,1,Low Mids,2,High Mids,3,Treble,4,Packed Map,5)]_EmissionAudioLinkChannel("Emisssion Audio Link Channel", int) = 0
+        [Enum(None,0,Bass,1,Low Mids,2,High Mids,3,Treble,4,Packed Map,5,UV Based,6)]_EmissionAudioLinkChannel("Emisssion Audio Link Channel", int) = 0
         [ToggleUI]_ALGradientOnRed("Gradient Red", Int) = 0
         [ToggleUI]_ALGradientOnGreen("Gradient Green", Int) = 0
         [ToggleUI]_ALGradientOnBlue("Gradient Blue", Int) = 0
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
 
         _ClipMap("Clip Map", 2D) = "black" {}
         _WireColor("Wire Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon3.0.shader.meta
+++ b/Main/Shaders/XSToon3.0.shader.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 85c615217d617204cb497ae6838b8bae
+guid: 3a74f10861cf4644cb585676682180ed
 ShaderImporter:
   externalObjects: {}
   defaultTextures:
@@ -18,6 +18,7 @@ ShaderImporter:
   - _OcclusionMap: {instanceID: 0}
   - _OutlineMask: {instanceID: 0}
   - _ThicknessMap: {instanceID: 0}
+  nonModifiableTextures: []
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Main/Shaders/XSToon3.0_Outlined.shader
+++ b/Main/Shaders/XSToon3.0_Outlined.shader
@@ -128,13 +128,14 @@
         [Enum(UV1,0,UV2,1)] _UVSetClipMap("Clip Map UVs", Int) = 0
         [Enum(UV1,0,UV2,1)] _UVSetDissolve("Dissolve Map UVs", Int) = 0
 
-        [Enum(None,0,Bass,1,Low Mids,2,High Mids,3,Treble,4,Packed Map,5)]_EmissionAudioLinkChannel("Emisssion Audio Link Channel", int) = 0
+        [Enum(None,0,Bass,1,Low Mids,2,High Mids,3,Treble,4,Packed Map,5,UV Based,6)]_EmissionAudioLinkChannel("Emisssion Audio Link Channel", int) = 0
         [ToggleUI]_ALGradientOnRed("Gradient Red", Int) = 0
         [ToggleUI]_ALGradientOnGreen("Gradient Green", Int) = 0
         [ToggleUI]_ALGradientOnBlue("Gradient Blue", Int) = 0
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
 
         _ClipMap("Clip Map", 2D) = "black" {}
         _WireColor("Wire Color", Color) = (0,0,0,0)

--- a/Main/Shaders/XSToon3.0_Outlined.shader.meta
+++ b/Main/Shaders/XSToon3.0_Outlined.shader.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 956a7ff9ce5a1cf4c8735b173dfac4bc
+guid: fd568e6ed04d8e241b02aed90d55738d
 ShaderImporter:
   externalObjects: {}
   defaultTextures:
@@ -18,6 +18,7 @@ ShaderImporter:
   - _OcclusionMap: {instanceID: 0}
   - _OutlineMask: {instanceID: 0}
   - _ThicknessMap: {instanceID: 0}
+  nonModifiableTextures: []
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
- new Emission Audio Link mode - "UV Based" that uses UVs selected in the Emission Map dropdown to apply audio link based effects
- new property _ALUVWidth which controls the sampling width of the Audio Link history


https://user-images.githubusercontent.com/3798928/120045494-cc0bb700-c018-11eb-885e-bc99e693c582.mp4

![image](https://user-images.githubusercontent.com/3798928/120045503-d62db580-c018-11eb-8c6f-6d02b9fb6e18.png)
