### PR TITLE
AudioLink: add default emission color when no AL available

### DIFF
--- a/Editor/XSToonInspector.cs
+++ b/Editor/XSToonInspector.cs
@@ -632,6 +632,9 @@ namespace XSToon3
                     if (isUVBased) {
                         materialEditor.ShaderProperty(_ALUVWidth, new GUIContent("History Sample Amount", "Controls the amount of Audio Link history to sample."));
                     }
+                    if (isAudioLink) {
+                        materialEditor.ColorProperty(_EmissionColor0, "AudioLink Emission");
+                    }
                 }
                 else
                 {

--- a/Editor/XSToonInspector.cs
+++ b/Editor/XSToonInspector.cs
@@ -75,6 +75,7 @@ namespace XSToon3
         protected MaterialProperty _EmissionColor = null;
         protected MaterialProperty _EmissionColor0 = null;
         protected MaterialProperty _EmissionColor1 = null;
+        protected MaterialProperty _EmissionColor2 = null;
         protected MaterialProperty _EmissionToDiffuse = null;
         protected MaterialProperty _RimColor = null;
         protected MaterialProperty _RimIntensity = null;
@@ -634,20 +635,20 @@ namespace XSToon3
                 }
                 else
                 {
-                    materialEditor.TexturePropertySingleLine(new GUIContent("Emission Map (VRC Audio Link Packed)", "Emissive map. Each channel controls different audio link reactions. RGB = Lows, Mids, Highs, Alpha Channel can be used to have extra masking as a way to combat aliasing"), _EmissionMap);
+                    materialEditor.TexturePropertySingleLine(new GUIContent("Emission Map (VRC Audio Link Packed)", "Emissive map. Each channel controls different audio link reactions. RGB = Lows, Mids, Highs, Alpha Channel can be used to have extra masking as a way to combat aliasing"), _EmissionMap, _EmissionColor);
                     materialEditor.TextureScaleOffsetProperty(_EmissionMap);
                     materialEditor.ShaderProperty(_UVSetEmission, new GUIContent("UV Set", "The UV set to use for the Emission Map"), 2);
                     materialEditor.ShaderProperty(_EmissionToDiffuse, new GUIContent("Tint To Diffuse", "Tints the emission to the Diffuse Color"), 2);
 
                     XSStyles.SeparatorThin();
 
-                    materialEditor.ColorProperty(_EmissionColor, "Red Ch. Color (Lows)");
+                    materialEditor.ColorProperty(_EmissionColor0, "Red Ch. Color (Lows)");
                     materialEditor.ShaderProperty(_ALGradientOnRed, new GUIContent("Gradient Bar", "Uses a gradient on this channel to create an animated bar from the audio link data."), 1);
 
-                    materialEditor.ColorProperty(_EmissionColor0, "Green Ch. Color (Mids)");
+                    materialEditor.ColorProperty(_EmissionColor1, "Green Ch. Color (Mids)");
                     materialEditor.ShaderProperty(_ALGradientOnGreen, new GUIContent("Gradient Bar", "Uses a gradient on this channel to create an animated bar from the audio link data."), 1);
 
-                    materialEditor.ColorProperty(_EmissionColor1, "Blue Ch. Color (Highs)");
+                    materialEditor.ColorProperty(_EmissionColor2, "Blue Ch. Color (Highs)");
                     materialEditor.ShaderProperty(_ALGradientOnBlue, new GUIContent("Gradient Bar", "Uses a gradient on this channel to create an animated bar from the audio link data."), 1);
                 }
 

--- a/Main/CGIncludes/XSDefines.cginc
+++ b/Main/CGIncludes/XSDefines.cginc
@@ -222,7 +222,7 @@ int _DissolveCoordinates;
 int _UseClipsForDissolve;
 
 half4 _ShadowRim, _OutlineColor, _SSColor,
-      _EmissionColor, _EmissionColor0, _EmissionColor1,
+      _EmissionColor, _EmissionColor0, _EmissionColor1, _EmissionColor2,
       _MatcapTint, _RimColor, _DissolveColor;
 
 half _MatcapTintToDiffuse;

--- a/Main/CGIncludes/XSLightingFunctions.cginc
+++ b/Main/CGIncludes/XSLightingFunctions.cginc
@@ -420,6 +420,7 @@ half4 calcEmission(FragmentData i, TextureUV t, DotProducts d, half lightAvg)
         }
         else
         {
+            emission = lerp(i.emissionMap.a, i.emissionMap.a * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor;
             if(AudioLinkIsAvailable())
             {
                 if(_EmissionAudioLinkChannel != 5)
@@ -433,7 +434,7 @@ half4 calcEmission(FragmentData i, TextureUV t, DotProducts d, half lightAvg)
                         aluv = int2(0, (_EmissionAudioLinkChannel-1));
                     }
                     float alink = lerp(1, AudioLinkData(aluv).x , saturate(_EmissionAudioLinkChannel));
-                    emission = lerp(i.emissionMap, i.emissionMap * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor * alink;
+                    emission = lerp(i.emissionMap, i.emissionMap * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor0 * alink;
                 }
                 else
                 {
@@ -445,14 +446,11 @@ half4 calcEmission(FragmentData i, TextureUV t, DotProducts d, half lightAvg)
                     float tMid = smoothstep((1-audioDataMids), (1-audioDataMids) + 0.01, i.emissionMap.g) * i.emissionMap.a;
                     float tHigh = smoothstep((1-audioDataHighs), (1-audioDataHighs) + 0.01, i.emissionMap.b) * i.emissionMap.a;
 
-                    float4 emissionChannelRed = lerp(i.emissionMap.r, tLow, _ALGradientOnRed) * _EmissionColor * audioDataBass;
-                    float4 emissionChannelGreen = lerp(i.emissionMap.g, tMid, _ALGradientOnGreen) * _EmissionColor0 * audioDataMids;
-                    float4 emissionChannelBlue = lerp(i.emissionMap.b, tHigh, _ALGradientOnBlue) * _EmissionColor1 * audioDataHighs;
+                    float4 emissionChannelRed = lerp(i.emissionMap.r, tLow, _ALGradientOnRed) * _EmissionColor0 * audioDataBass;
+                    float4 emissionChannelGreen = lerp(i.emissionMap.g, tMid, _ALGradientOnGreen) * _EmissionColor1 * audioDataMids;
+                    float4 emissionChannelBlue = lerp(i.emissionMap.b, tHigh, _ALGradientOnBlue) * _EmissionColor2 * audioDataHighs;
                     emission = (emissionChannelRed + emissionChannelGreen + emissionChannelBlue) * lerp(1, i.diffuseColor.rgbb, _EmissionToDiffuse);
                 }
-            } else if (_EmissionAudioLinkChannel == 5) {
-                // no AudioLink
-                emission = lerp(i.emissionMap.a, i.emissionMap.a * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor;
             }
         }
 

--- a/Main/CGIncludes/XSLightingFunctions.cginc
+++ b/Main/CGIncludes/XSLightingFunctions.cginc
@@ -450,6 +450,9 @@ half4 calcEmission(FragmentData i, TextureUV t, DotProducts d, half lightAvg)
                     float4 emissionChannelBlue = lerp(i.emissionMap.b, tHigh, _ALGradientOnBlue) * _EmissionColor1 * audioDataHighs;
                     emission = (emissionChannelRed + emissionChannelGreen + emissionChannelBlue) * lerp(1, i.diffuseColor.rgbb, _EmissionToDiffuse);
                 }
+            } else if (_EmissionAudioLinkChannel == 5) {
+                // no AudioLink
+                emission = lerp(i.emissionMap.a, i.emissionMap.a * i.diffuseColor.xyzz, _EmissionToDiffuse) * _EmissionColor;
             }
         }
 

--- a/Main/Plugins/Iridescent/XSToon3.0_Iridescent.shader
+++ b/Main/Plugins/Iridescent/XSToon3.0_Iridescent.shader
@@ -134,6 +134,7 @@
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [HDR]_EmissionColor2("Emission Packed Color 3", Color) = (0,0,0,0)
         [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
         
         _Iridescent("Iridescent Gardient", 2D) = "white" {}

--- a/Main/Plugins/ParticleGeometryMeshReconstruction/XSToon3.0_MeshReconstruction.shader
+++ b/Main/Plugins/ParticleGeometryMeshReconstruction/XSToon3.0_MeshReconstruction.shader
@@ -135,6 +135,7 @@
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [HDR]_EmissionColor2("Emission Packed Color 3", Color) = (0,0,0,0)
         [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
 
         _ClipMap("Clip Map", 2D) = "black" {}

--- a/Main/Shaders/XSToon3.0.shader
+++ b/Main/Shaders/XSToon3.0.shader
@@ -137,6 +137,7 @@
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [HDR]_EmissionColor2("Emission Packed Color 3", Color) = (0,0,0,0)
         [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
 
         _ClipMap("Clip Map", 2D) = "black" {}

--- a/Main/Shaders/XSToon3.0_Outlined.shader
+++ b/Main/Shaders/XSToon3.0_Outlined.shader
@@ -137,6 +137,7 @@
         [HDR]_EmissionColor("Emission Color", Color) = (0,0,0,0)
         [HDR]_EmissionColor0("Emission Packed Color 1", Color) = (0,0,0,0)
         [HDR]_EmissionColor1("Emission Packed Color 2", Color) = (0,0,0,0)
+        [HDR]_EmissionColor2("Emission Packed Color 3", Color) = (0,0,0,0)
         [IntRange]_ALUVWidth("History Sample Amount", Range(0,128)) = 128
 
         _ClipMap("Clip Map", 2D) = "black" {}


### PR DESCRIPTION
Might be worth switching bass/low/high/treble to `_EmissionColor0` with a default on `_EmissionColor` as well, this would allow a unconditional  (if `_EmissionAudioLinkChannel != 0`) preset default beforehand with post-multiply using emission map alpha (makes it branchless).