### PR TITLE
shadow ramp: support transparency

### DIFF
--- a/Editor/XSGradientEditor.cs
+++ b/Editor/XSGradientEditor.cs
@@ -390,6 +390,7 @@ namespace XSToon3
                 texture.maxTextureSize = 512;
                 texture.mipmapEnabled = false;
                 texture.textureCompression = TextureImporterCompression.Uncompressed;
+                texture.alphaIsTransparency = true;
 
                 // texture.sRGBTexture = !isLinear; // We already do the conversion in tex.SetPixel
 

--- a/Main/CGIncludes/XSLightingFunctions.cginc
+++ b/Main/CGIncludes/XSLightingFunctions.cginc
@@ -355,7 +355,7 @@ half4 calcDiffuse(FragmentData i, DotProducts d, half3 indirectDiffuse, half4 li
     half grayIndirect = dot(indirectDiffuse, float3(1,1,1));
     half attenFactor = lerp(i.attenuation, 1, smoothstep(0, 0.2, grayIndirect));
 
-    diffuse = ramp * attenFactor * lightCol + indirect;
+    diffuse = lerp(1, ramp, ramp.a) * attenFactor * lightCol + indirect;
     diffuse = i.albedo * diffuse;
     return diffuse;
 }


### PR DESCRIPTION
Probably could be improved but simple proof-of-concept which seems to work somewhat. Suggestions welcome.